### PR TITLE
feat: Added support for running on the Raspberry Pi Zero W.

### DIFF
--- a/lib/switchbot-device.js
+++ b/lib/switchbot-device.js
@@ -38,6 +38,7 @@ class SwitchbotDevice {
     this._modelName = ad.serviceData.modelName;
 
     this._was_connected_explicitly = false;
+    this._connected = false;
 
     this._onconnect = () => { };
     this._ondisconnect = () => { };
@@ -59,7 +60,11 @@ class SwitchbotDevice {
     return this._modelName;
   }
   get connectionState() {
-    return this._peripheral.state;
+    if (!this._connected && this._peripheral.state === 'disconnecting') {
+      return 'disconnected';
+    } else {
+      return this._peripheral.state;
+    }
   }
 
   // Setters
@@ -106,10 +111,12 @@ class SwitchbotDevice {
 
       // Set event handlers for events fired on the `Peripheral` object
       this._peripheral.once('connect', () => {
+        this._connected = true;
         this._onconnect();
       });
 
       this._peripheral.once('disconnect', () => {
+        this._connected = false;
         this._chars = null;
         this._peripheral.removeAllListeners();
         this._ondisconnect_internal();


### PR DESCRIPTION
On the Raspberry Pi Zero W, after being disconnected, _peripheral .state is frequently changed to disconnecting, and once that happens, the connection will not be possible.

For this reason, I have changed the behavior as follows.
 * After disconnecting, _peripheral. state is disconnecting, it behavior as disconnected.