### PR TITLE
Filter by address instead of id for macOS support

### DIFF
--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -81,7 +81,7 @@ class Switchbot {
       let valid = parameterChecker.check(params, {
         duration: { required: false, type: 'integer', min: 1, max: 60000 },
         model: { required: false, type: 'string', enum: ['H', 'T', 'c'] },
-        id: { required: false, type: 'string', min: 12, max: 17 },
+        address: { required: false, type: 'string', min: 12, max: 17 },
         quick: { required: false, type: 'boolean' }
       }, false);
 
@@ -98,7 +98,7 @@ class Switchbot {
       let p = {
         duration: params.duration || this._DEFAULT_DISCOVERY_DURATION,
         model: params.model || '',
-        id: params.id || '',
+        address: params.address || '',
         quick: params.quick ? true : false
       };
 
@@ -121,12 +121,11 @@ class Switchbot {
 
         // Set an handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
-          let device = this._getDeviceObject(peripheral, p.id, p.model);
+          let device = this._getDeviceObject(peripheral, p.address, p.model);
           if (!device) {
             return;
           }
-          let id = device.id;
-          peripherals[id] = device;
+          peripherals[device.address] = device;
 
           if (this.ondiscover && typeof (this.ondiscover) === 'function') {
             this.ondiscover(device);
@@ -179,9 +178,9 @@ class Switchbot {
     return promise;
   }
 
-  _getDeviceObject(peripheral, id, model) {
+  _getDeviceObject(peripheral, address, model) {
     let ad = switchbotAdvertising.parse(peripheral);
-    if (this._filterAdvertising(ad, id, model)) {
+    if (this._filterAdvertising(ad, address, model)) {
       let device = null;
       if (ad.serviceData.model === 'H') {
         device = new SwitchbotDeviceWoHand(peripheral);
@@ -198,13 +197,12 @@ class Switchbot {
     }
   }
 
-  _filterAdvertising(ad, id, model) {
+  _filterAdvertising(ad, address, model) {
     if (!ad) {
       return false;
     }
-    if (id) {
-      id = id.toLowerCase().replace(/\:/g, '');
-      if (ad.id !== id) {
+    if (address) {
+      if (!ad.address.match(new RegExp(address.replace(/:/g, '.'), 'i'))) {
         return false;
       }
     }
@@ -246,7 +244,7 @@ class Switchbot {
       // Check the parameters
       let valid = parameterChecker.check(params, {
         model: { required: false, type: 'string', enum: ['H', 'T', 'c'] },
-        id: { required: false, type: 'string', min: 12, max: 17 },
+        address: { required: false, type: 'string', min: 12, max: 17 },
       }, false);
 
       if (!valid) {
@@ -264,13 +262,13 @@ class Switchbot {
         // Determine the values of the parameters
         let p = {
           model: params.model || '',
-          id: params.id || ''
+          address: params.address || ''
         };
 
         // Set an handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
           let ad = switchbotAdvertising.parse(peripheral);
-          if (this._filterAdvertising(ad, p.id, p.model)) {
+          if (this._filterAdvertising(ad, p.address, p.model)) {
             if (this.onadvertisement && typeof (this.onadvertisement) === 'function') {
               this.onadvertisement(ad);
             }

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -59,11 +59,11 @@ class Switchbot {
   *              |         |          | If "H" is specified, this method will discover
   *              |         |          | only Bots. If "T" is specified, this method
   *              |         |          | will discover only Meters.
-  *   - id       | String  | Optional | If this value is set, this method willl discover
-  *              |         |          | only a device whose ID is as same as this value.
-  *              |         |          | The ID is identical to the MAC address.
-  *              |         |          | This parameter is case-insensitive, and
-  *              |         |          | colons are ignored.
+  *   - address  | String  | Optional | If this value is set, this method will discover
+  *              |         |          | only a device whose MAC address is as same as
+  *              |         |          | this value.
+  *              |         |          | This parameter is case-insensitive, colons
+  *              |         |          | and hyphens are ignored.
   *   - quick    | Boolean | Optional | If this value is true, this method finishes
   *              |         |          | the discovery process when the first device
   *              |         |          | is found, then calls the resolve() function
@@ -227,14 +227,12 @@ class Switchbot {
   *              |         |          | If "T" is specified, the `onadvertisement`
   *              |         |          | event hander will be called only when advertising
   *              |         |          | packets comes from Meters.
-  *   - id       | String  | Optional | If this value is set, the `onadvertisement`
+  *   - address  | String  | Optional | If this value is set, the `onadvertisement`
   *              |         |          | event hander will be called only when advertising
-  *              |         |          | packets comes from devices whose ID is as same as
-  *              |         |          | this value.
-  *              |         |          | The ID is identical to the MAC address.
-  *              |         |          | This parameter is case-insensitive, and
-  *              |         |          | colons are ignored.
-  *
+  *              |         |          | packets comes from devices whose address is as same
+  *              |         |          | as this value.
+  *              |         |          | This parameter is case-insensitive, colons
+  *              |         |          | and hyphens are ignored.
   * [Returen value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.


### PR DESCRIPTION
This pull request uses the `address` field instead of the `id` field to filter advertisement data to support macOS as well as Linux.

The following code performs differently on macOS and Linux:
```
const noble = require('@abandonware/noble');

const uuidPrimary = 'cba20d00224d11e69fb80002a5d5c51b';
const uuidWrite = 'cba20002224d11e69fb80002a5d5c51b';

noble.on('stateChange', state => {
  if (state === 'poweredOn') {
    noble.startScanning([uuidPrimary], false);
  } else {
    noble.stopScanning();
  }
});

noble.on('discover', peripheral => {
  console.log(`ID: ${peripheral.id}\nAddress: ${peripheral.address}\n`);
});
```

On Linux the ID and the address are equivalent:
```
ID: f544e3xxxxxx
Address: f5:44:e3:xx:xx:xx
```

On macOS the ID is a UUID and the MAC address is hyphenated:
```
ID: 2a33318ee2654f60xxxxxxxxxxxxxxxx
Address: f5-44-e3-xx-xx-xx
```
