### PR TITLE
Fix for #71 (SwitchBot "Contact" and "Motion")

### DIFF
--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -10,10 +10,10 @@ class SwitchbotAdvertising {
   * [Arguments]
   * - peripheral | Object  | Required | A `Peripheral` object of noble
   *
-  * [Returen value]
+  * [Return value]
   * - An object as follows:
   *
-  * WoHand	
+  * WoHand
   * {
   *   id: 'c12e453e2008',
   *   address: 'c1:2e:45:3e:20:08',
@@ -56,7 +56,7 @@ class SwitchbotAdvertising {
   *     lightLevel: 1
   *   }
   * }
-  * 
+  *
   * If the specified `Peripheral` does not represent any switchbot
   * device, this method will return `null`.
   * ---------------------------------------------------------------- */

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -65,10 +65,8 @@ class SwitchbotAdvertising {
     if (!ad || !ad.serviceData) {
       return null;
     }
-    if (ad.serviceData[0].uuid !== '0d00') {
-      return null;
-    }
-    let buf = ad.serviceData[0].data;
+    let serviceData = ad.serviceData[0] || ad.serviceData;
+    let buf = serviceData.data;
     if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
       return null;
     }

--- a/lib/switchbot-device-wocurtain.js
+++ b/lib/switchbot-device-wocurtain.js
@@ -10,7 +10,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
     * [Arguments]
     * - none
     *
-    * [Returen value]
+    * [Return value]
     * - Promise object
     *   Nothing will be passed to the `resolve()`.
     * ---------------------------------------------------------------- */
@@ -25,7 +25,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
     * [Arguments]
     * - none
     *
-    * [Returen value]
+    * [Return value]
     * - Promise object
     *   Nothing will be passed to the `resolve()`.
     * ---------------------------------------------------------------- */
@@ -40,7 +40,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
     * [Arguments]
     * - none
     *
-    * [Returen value]
+    * [Return value]
     * - Promise object
     *   Nothing will be passed to the `resolve()`.
     * ---------------------------------------------------------------- */
@@ -55,7 +55,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
     * [Arguments]
     * - percent | number | Required | the percentage of target position
     *
-    * [Returen value]
+    * [Return value]
     * - Promise object
     *   Nothing will be passed to the `resolve()`.
     * ---------------------------------------------------------------- */

--- a/lib/switchbot-device-wohand.js
+++ b/lib/switchbot-device-wohand.js
@@ -10,7 +10,7 @@ class SwitchbotDeviceWoHand extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -25,7 +25,7 @@ class SwitchbotDeviceWoHand extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -40,7 +40,7 @@ class SwitchbotDeviceWoHand extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -55,7 +55,7 @@ class SwitchbotDeviceWoHand extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -70,7 +70,7 @@ class SwitchbotDeviceWoHand extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */

--- a/lib/switchbot-device-wohumi.js
+++ b/lib/switchbot-device-wohumi.js
@@ -10,7 +10,7 @@ class SwitchbotDeviceWoHumi extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -25,7 +25,7 @@ class SwitchbotDeviceWoHumi extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -40,7 +40,7 @@ class SwitchbotDeviceWoHumi extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -55,7 +55,7 @@ class SwitchbotDeviceWoHumi extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -70,7 +70,7 @@ class SwitchbotDeviceWoHumi extends SwitchbotDevice {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */

--- a/lib/switchbot-device.js
+++ b/lib/switchbot-device.js
@@ -5,7 +5,7 @@ const switchbotAdvertising = require('./switchbot-advertising.js');
 class SwitchbotDevice {
   /* ------------------------------------------------------------------
   * Constructor
-  *	
+  *
   * [Arguments]
   * - peripheral | Object | Required | The `peripheral` object of noble,
   *              |        |          | which represents this device
@@ -83,7 +83,7 @@ class SwitchbotDevice {
   * [Arguments]
   * -  none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -285,7 +285,7 @@ class SwitchbotDevice {
   * [Arguments]
   * -  none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -329,7 +329,7 @@ class SwitchbotDevice {
   * [Arguments]
   * -  none
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   The device name will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -361,7 +361,7 @@ class SwitchbotDevice {
   * - name | String | Required | Device name. The bytes length of the name
   *        |        |          | must be in the range of 1 to 20 bytes.
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -13,7 +13,7 @@ const SwitchbotDeviceWoHumi = require('./switchbot-device-wohumi.js');
 class Switchbot {
   /* ------------------------------------------------------------------
   * Constructor
-  *	
+  *
   * [Arguments]
   * - params  | Object  | Optional |
   *   - noble | Noble   | Optional | The Nobel object created by the noble module.
@@ -30,7 +30,7 @@ class Switchbot {
       noble = require('@abandonware/noble');
     }
 
-    // Plublic properties
+    // Public properties
     this.noble = noble;
     this.ondiscover = null;
     this.onadvertisement = null;
@@ -57,7 +57,7 @@ class Switchbot {
   *              |         |          | If "s" is specified, this method will discover only Motion Sensors.
   *              |         |          | If "d" is specified, this method will discover only Contact Sensors.
   *              |         |          | If "c" is specified, this method will discover only Curtains.
-  *   - id       | String  | Optional | If this value is set, this method willl discover
+  *   - id       | String  | Optional | If this value is set, this method will discover
   *              |         |          | only a device whose ID is as same as this value.
   *              |         |          | The ID is identical to the MAC address.
   *              |         |          | This parameter is case-insensitive, and
@@ -68,7 +68,7 @@ class Switchbot {
   *              |         |          | without waiting the specified duration.
   *              |         |          | The default value is false.
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   An array will be passed to the `resolve()`, which includes
   *   `SwitchbotDevice` objects representing the found devices.
@@ -117,7 +117,7 @@ class Switchbot {
           resolve(device_list);
         };
 
-        // Set an handler for the 'discover' event
+        // Set a handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
           let device = this._getDeviceObject(peripheral, p.id, p.model);
           if (!device) {
@@ -136,7 +136,7 @@ class Switchbot {
           }
         });
 
-        // Start scaning
+        // Start scanning
         this.noble.startScanning(this._PRIMARY_SERVICE_UUID_LIST, false, (error) => {
           if (error) {
             reject(error);
@@ -236,32 +236,32 @@ class Switchbot {
   *   - params   | Object  | Optional |
   *   - model    | String  | Optional | "H", "T", "e", "s", "d", or "c".
   *              |         |          | If "H" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Bots.
   *              |         |          | If "T" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Meters.
   *              |         |          | If "e" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Humidifiers.
   *              |         |          | If "s" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Motion Sensor.
   *              |         |          | If "d" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Contact Sensor.
   *              |         |          | If "c" is specified, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from Curtains.
   *   - id       | String  | Optional | If this value is set, the `onadvertisement`
-  *              |         |          | event hander will be called only when advertising
+  *              |         |          | event handler will be called only when advertising
   *              |         |          | packets comes from devices whose ID is as same as
   *              |         |          | this value.
   *              |         |          | The ID is identical to the MAC address.
   *              |         |          | This parameter is case-insensitive, and
   *              |         |          | colons are ignored.
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */
@@ -291,7 +291,7 @@ class Switchbot {
           id: params.id || ''
         };
 
-        // Set an handler for the 'discover' event
+        // Set a handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
           let ad = switchbotAdvertising.parse(peripheral);
           if (this._filterAdvertising(ad, p.id, p.model)) {
@@ -301,7 +301,7 @@ class Switchbot {
           }
         });
 
-        // Start scaning
+        // Start scanning
         this.noble.startScanning(this._PRIMARY_SERVICE_UUID_LIST, true, (error) => {
           if (error) {
             reject(error);
@@ -323,7 +323,7 @@ class Switchbot {
   * [Arguments]
   * - none
   *
-  * [Returen value]
+  * [Return value]
   * - none
   * ---------------------------------------------------------------- */
   stopScan() {
@@ -338,7 +338,7 @@ class Switchbot {
   * [Arguments]
   * - msec | Integer | Required | Msec.
   *
-  * [Returen value]
+  * [Return value]
   * - Promise object
   *   Nothing will be passed to the `resolve()`.
   * ---------------------------------------------------------------- */

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -38,7 +38,7 @@ class Switchbot {
     // Private properties
     this._scanning = false;
     this._DEFAULT_DISCOVERY_DURATION = 5000
-    this._PRIMARY_SERVICE_UUID_LIST = ['cba20d00224d11e69fb80002a5d5c51b'];
+    this._PRIMARY_SERVICE_UUID_LIST = [];
   };
 
   /* ------------------------------------------------------------------


### PR DESCRIPTION
## :recycle: Current situation

This pull request relates to issue #71 

The current situation is that SwitchBot "Contact" and "Motion" are not working with this module.

These models are already handled, however I have found 2 problems which prevent them from being discovered:

1) Both models are not discovered by the Service UUID `cba20d00224d11e69fb80002a5d5c51b` because for both models `peripheral.advertisement.serviceUuids` is an empty array.

2) For both models `peripheral.advertisement.serviceData` is no array unlike the other models.

## :bulb: Proposed solution

1) I changed `_PRIMARY_SERVICE_UUID_LIST` to an empty array (=> [any service UUID](https://github.com/abandonware/noble#start-scanning))

```js
    this._PRIMARY_SERVICE_UUID_LIST = [];
```

2) I added `serviceData` as default value if `serviceData[0]` is undefined.

```js
    let serviceData = ad.serviceData[0] || ad.serviceData;
```

## :gear: Release Notes

* Added support for SwitchBot "Contact" and "Motion"

## :heavy_plus_sign: Additional Information

I also corrected some typos.

### Testing

I tested the advertising data with 6 devices (1 Contact, 1 Motion, 2 Meter and 2 Bot) on the terminal.