### PR TITLE
Solves Bug #101

### DIFF
--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -63,17 +63,11 @@ class SwitchbotAdvertising {
   parse(peripheral, onlog) {
     let ad = peripheral.advertisement;
     if (!ad || !ad.serviceData) {
-      // if (onlog && typeof onlog === 'function') {
-      //   onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no serviceData!`);
-      // }
       return null;
     }
     let serviceData = ad.serviceData[0] || ad.serviceData;
     let buf = serviceData.data;
     if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
-      // if (onlog && typeof onlog === 'function') {
-      //   onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no buffer!`);
-      // }
       return null;
     }
 
@@ -94,7 +88,7 @@ class SwitchbotAdvertising {
       sd = this._parseServiceDataForWoContact(buf, onlog);
     } else {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising.${peripheral.id}] return null, model ${model} not detected!`);
+        onlog(`[parseAdvertising.${peripheral.id}] return null, model "${model}" not available!`);
       }
       return null;
     }
@@ -128,7 +122,7 @@ class SwitchbotAdvertising {
     };
     
     if (onlog && typeof onlog === 'function') {
-      onlog(`[parseAdvertising.${peripheral.id}.${model}] result: ${JSON.stringify(data)}`);
+      onlog(`[parseAdvertising.${peripheral.id}.${model}] return ${JSON.stringify(data)}`);
     }
     return data;
   }
@@ -281,9 +275,9 @@ class SwitchbotAdvertising {
   }
 
   _parseServiceDataForWoCurtain(buf, onlog) {
-    if (buf.length !== 6) {
+    if (buf.length !== 5 && buf.length !== 6) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[_parseServiceDataForWoCurtain] Buffer length ${buf.length} !== 6!`);
+        onlog(`[_parseServiceDataForWoCurtain] Buffer length ${buf.length} !== 5 or 6!`);
       }
       return null;
     }

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -63,17 +63,17 @@ class SwitchbotAdvertising {
   parse(peripheral, onlog) {
     let ad = peripheral.advertisement;
     if (!ad || !ad.serviceData) {
-      if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no serviceData!`);
-      }
+      // if (onlog && typeof onlog === 'function') {
+      //   onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no serviceData!`);
+      // }
       return null;
     }
     let serviceData = ad.serviceData[0] || ad.serviceData;
     let buf = serviceData.data;
     if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
-      if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no buffer!`);
-      }
+      // if (onlog && typeof onlog === 'function') {
+      //   onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no buffer!`);
+      // }
       return null;
     }
 
@@ -81,17 +81,17 @@ class SwitchbotAdvertising {
     let sd = null;
 
     if (model === 'H') { // WoHand
-      sd = this._parseServiceDataForWoHand(buf);
+      sd = this._parseServiceDataForWoHand(buf, onlog);
     } else if (model === 'e') { // WoHumi
-      sd = this._parseServiceDataForWoHumi(buf);
+      sd = this._parseServiceDataForWoHumi(buf), onlog;
     } else if (model === 'T') { // WoSensorTH
-      sd = this._parseServiceDataForWoSensorTH(buf);
+      sd = this._parseServiceDataForWoSensorTH(buf, onlog);
     } else if (model === 'c') { // WoCurtain
-      sd = this._parseServiceDataForWoCurtain(buf);
+      sd = this._parseServiceDataForWoCurtain(buf, onlog);
     } else if (model === 's') { // WoMotion
-      sd = this._parseServiceDataForWoPresence(buf);
+      sd = this._parseServiceDataForWoPresence(buf, onlog);
     } else if (model === 'd') { // WoContact
-      sd = this._parseServiceDataForWoContact(buf);
+      sd = this._parseServiceDataForWoContact(buf, onlog);
     } else {
       if (onlog && typeof onlog === 'function') {
         onlog(`[parseAdvertising.${peripheral.id}] return null, model ${model} not detected!`);
@@ -101,7 +101,7 @@ class SwitchbotAdvertising {
 
     if (!sd) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising.${peripheral.id}] return null, parsed serviceData empty!`);
+        onlog(`[parseAdvertising.${peripheral.id}.${model}] return null, parsed serviceData empty!`);
       }
       return null;
     }
@@ -128,13 +128,16 @@ class SwitchbotAdvertising {
     };
     
     if (onlog && typeof onlog === 'function') {
-      onlog(`[parseAdvertising.${peripheral.id}] result: ${JSON.stringify(data)}`);
+      onlog(`[parseAdvertising.${peripheral.id}.${model}] result: ${JSON.stringify(data)}`);
     }
     return data;
   }
 
-  _parseServiceDataForWoHand(buf) {
+  _parseServiceDataForWoHand(buf, onlog) {
     if (buf.length !== 3) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoHand] Buffer length ${buf.length} !== 3!`);
+      }
       return null;
     }
     let byte1 = buf.readUInt8(1);
@@ -155,8 +158,11 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoHumi(buf) {
+  _parseServiceDataForWoHumi(buf, onlog) {
     if (buf.length !== 8) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoHumi] Buffer length ${buf.length} !== 8!`);
+      }
       return null;
     }
     let byte1 = buf.readUInt8(1);
@@ -180,8 +186,11 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoSensorTH(buf) {
+  _parseServiceDataForWoSensorTH(buf, onlog) {
     if (buf.length !== 6) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoSensorTH] Buffer length ${buf.length} !== 6!`);
+      }
       return null;
     }
     let byte2 = buf.readUInt8(2);
@@ -209,8 +218,11 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoPresence(buf) {
+  _parseServiceDataForWoPresence(buf, onlog) {
     if (buf.length !== 6) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoPresence] Buffer length ${buf.length} !== 6!`);
+      }
       return null;
     }
     let byte1 = buf.readUInt8(1);
@@ -234,8 +246,11 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoContact(buf) {
+  _parseServiceDataForWoContact(buf, onlog) {
     if (buf.length !== 9) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoContact] Buffer length ${buf.length} !== 9!`);
+      }
       return null;
     }
 
@@ -265,8 +280,11 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoCurtain(buf) {
+  _parseServiceDataForWoCurtain(buf, onlog) {
     if (buf.length !== 5) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[_parseServiceDataForWoCurtain] Buffer length ${buf.length} !== 5!`);
+      }
       return null;
     }
     let byte1 = buf.readUInt8(1);

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -281,9 +281,9 @@ class SwitchbotAdvertising {
   }
 
   _parseServiceDataForWoCurtain(buf, onlog) {
-    if (buf.length !== 5) {
+    if (buf.length !== 6) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[_parseServiceDataForWoCurtain] Buffer length ${buf.length} !== 5!`);
+        onlog(`[_parseServiceDataForWoCurtain] Buffer length ${buf.length} !== 6!`);
       }
       return null;
     }
@@ -291,6 +291,7 @@ class SwitchbotAdvertising {
     let byte2 = buf.readUInt8(2);
     let byte3 = buf.readUInt8(3);
     let byte4 = buf.readUInt8(4);
+    // let byte5 = buf.readUInt8(5);
 
     let calibration = (byte1 & 0b01000000) ? true : false; // Whether the calibration is completed
     let battery = byte2 & 0b01111111; // %

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -64,7 +64,7 @@ class SwitchbotAdvertising {
     let ad = peripheral.advertisement;
     if (!ad || !ad.serviceData) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising] return null, Empty or no serviceData!`);
+        onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no serviceData!`);
       }
       return null;
     }
@@ -72,7 +72,7 @@ class SwitchbotAdvertising {
     let buf = serviceData.data;
     if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising] return null, Empty or no buffer!`);
+        onlog(`[parseAdvertising.${peripheral.id}] return null, Empty or no buffer!`);
       }
       return null;
     }
@@ -94,14 +94,14 @@ class SwitchbotAdvertising {
       sd = this._parseServiceDataForWoContact(buf);
     } else {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising] model ${model} not detected!`);
+        onlog(`[parseAdvertising.${peripheral.id}] return null, model ${model} not detected!`);
       }
       return null;
     }
 
     if (!sd) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[parseAdvertising] parsed serviceData empty!`);
+        onlog(`[parseAdvertising.${peripheral.id}] return null, parsed serviceData empty!`);
       }
       return null;
     }
@@ -128,7 +128,7 @@ class SwitchbotAdvertising {
     };
     
     if (onlog && typeof onlog === 'function') {
-      onlog(`[parseAdvertising] result: ${JSON.stringify(data)}`);
+      onlog(`[parseAdvertising.${peripheral.id}] result: ${JSON.stringify(data)}`);
     }
     return data;
   }

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -60,14 +60,20 @@ class SwitchbotAdvertising {
   * If the specified `Peripheral` does not represent any switchbot
   * device, this method will return `null`.
   * ---------------------------------------------------------------- */
-  parse(peripheral) {
+  parse(peripheral, onlog) {
     let ad = peripheral.advertisement;
     if (!ad || !ad.serviceData) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[parseAdvertising] return null, Empty or no serviceData!`);
+      }
       return null;
     }
     let serviceData = ad.serviceData[0] || ad.serviceData;
     let buf = serviceData.data;
     if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[parseAdvertising] return null, Empty or no buffer!`);
+      }
       return null;
     }
 
@@ -87,10 +93,16 @@ class SwitchbotAdvertising {
     } else if (model === 'd') { // WoContact
       sd = this._parseServiceDataForWoContact(buf);
     } else {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[parseAdvertising] model ${model} not detected!`);
+      }
       return null;
     }
 
     if (!sd) {
+      if (onlog && typeof onlog === 'function') {
+        onlog(`[parseAdvertising] parsed serviceData empty!`);
+      }
       return null;
     }
     let address = peripheral.address || '';
@@ -114,6 +126,10 @@ class SwitchbotAdvertising {
       rssi: peripheral.rssi,
       serviceData: sd
     };
+    
+    if (onlog && typeof onlog === 'function') {
+      onlog(`[parseAdvertising] result: ${JSON.stringify(data)}`);
+    }
     return data;
   }
 

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -77,7 +77,7 @@ class SwitchbotAdvertising {
     if (model === 'H') { // WoHand
       sd = this._parseServiceDataForWoHand(buf, onlog);
     } else if (model === 'e') { // WoHumi
-      sd = this._parseServiceDataForWoHumi(buf), onlog;
+      sd = this._parseServiceDataForWoHumi(buf, onlog);
     } else if (model === 'T') { // WoSensorTH
       sd = this._parseServiceDataForWoSensorTH(buf, onlog);
     } else if (model === 'c') { // WoCurtain

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -179,7 +179,7 @@ class Switchbot {
   }
 
   _getDeviceObject(peripheral, id, model) {
-    let ad = switchbotAdvertising.parse(peripheral);
+    let ad = switchbotAdvertising.parse(peripheral, this.onlog);
     if (this._filterAdvertising(ad, id, model)) {
       let device = null;
       switch (ad.serviceData.model) {

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -34,6 +34,7 @@ class Switchbot {
     this.noble = noble;
     this.ondiscover = null;
     this.onadvertisement = null;
+    this.onlog = null;
 
     // Private properties
     this._scanning = false;
@@ -293,7 +294,13 @@ class Switchbot {
 
         // Set a handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
+          if (this.onlog && typeof this.onlog === 'function') {
+            this.onlog(`[startScan.discover.beforeParse] ${JSON.stringify(peripheral)}`);
+          }
           let ad = switchbotAdvertising.parse(peripheral);
+          if (this.onlog && typeof this.onlog === 'function') {
+            this.onlog(`[startScan.discover.afterParse] ${JSON.stringify(ad)}`);
+          }
           if (this._filterAdvertising(ad, p.id, p.model)) {
             if (this.onadvertisement && typeof (this.onadvertisement) === 'function') {
               this.onadvertisement(ad);

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -294,13 +294,7 @@ class Switchbot {
 
         // Set a handler for the 'discover' event
         this.noble.on('discover', (peripheral) => {
-          if (this.onlog && typeof this.onlog === 'function') {
-            this.onlog(`[startScan.discover.beforeParse] ${JSON.stringify(peripheral)}`);
-          }
-          let ad = switchbotAdvertising.parse(peripheral);
-          if (this.onlog && typeof this.onlog === 'function') {
-            this.onlog(`[startScan.discover.afterParse] ${JSON.stringify(ad)}`);
-          }
+          let ad = switchbotAdvertising.parse(peripheral, this.onlog);
           if (this._filterAdvertising(ad, p.id, p.model)) {
             if (this.onadvertisement && typeof (this.onadvertisement) === 'function') {
               this.onadvertisement(ad);


### PR DESCRIPTION
## :recycle: Current situation

Curtains with firmware 3.9 are not being detected anymore (#101). While analyzing the advertisement the buffer size has to be a length of 5 otherwise the curtain is not being detected. Unfortunately, the new length of the buffer size is 6.

## :bulb: Proposed solution

Check for a length of 5 or 6. Some users might not be using the newest firmware yet.

## :gear: Release Notes

Curtains support firmware 3.9 

## :heavy_plus_sign: Additional Information
Added logging capabilities during the advertisement. They can be accessed by assigning a function to `onlog`. Might be useful for the developers who implement this module.

### Testing

Tested the curtains with firmware 3.9 by using the iobroker.switchbot-ble adapter.

