### PR TITLE
add support for Plug Mini (JP)

### DIFF
--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -98,7 +98,7 @@ class SwitchbotAdvertising {
     } else if (model === 'g') { // WoPlugMini
       sd = this._parseServiceDataForWoPlugMini(buf, onlog);
     } else if (model === 'j') { // WoPlugMini (JP) ?? 
-      sd = this._parseServiceDataForWoPlugMiniJ(manufacturerData, onlog);
+      sd = this._parseServiceDataForWoPlugMini(manufacturerData, onlog);
     } else if (model === 'o') { // WoSmartLock
       sd = this._parseServiceDataForWoSmartLock(buf, onlog);
     } else if (model === 'i') { // WoMeterPlus
@@ -122,7 +122,7 @@ class SwitchbotAdvertising {
     if (address === '') {
       address = peripheral.advertisement.manufacturerData || '';
       if (address !== '') {
-        const str = peripheral.advertisement.manufacturerData.toString('hex')?.slice(4,16);
+        const str = peripheral.advertisement.manufacturerData.toString('hex').slice(4,16);
         address = str.substr(0, 2);
         for (var i = 2; i < str.length; i += 2) {
           address = address + ":" + str.substr(i, 2);
@@ -344,10 +344,10 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoPlugMiniJ(buf, onlog) {
+  _parseServiceDataForWoPlugMini(buf, onlog) {
     if (buf.length !== 14) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[_parseServiceDataForWoPlugMiniJ] Buffer length ${buf.length} !== 6!`);
+        onlog(`[_parseServiceDataForWoPlugMini] Buffer length ${buf.length} should be 14`);
       }
       return null;
     }
@@ -363,7 +363,8 @@ class SwitchbotAdvertising {
     const syncUtcTime = !! (byte10 & 0b00000100);
     const wifiRssi = byte11;
     const overload = !! (byte12 & 0b10000000);
-    const currentPower = (((byte12 & 0b01111111) << 8) + byte13) / 10;
+    const currentPower = (((byte12 & 0b01111111) << 8) + byte13) / 10; // in watt
+    // TODO: voltage ???
 
     const data = {
       model: 'j',
@@ -374,7 +375,7 @@ class SwitchbotAdvertising {
       syncUtcTime: syncUtcTime,
       wifiRssi: wifiRssi,
       overload: overload,
-      currentPower: currentPower
+      currentPower: currentPower,
     };
 
     return data;

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -66,8 +66,15 @@ class SwitchbotAdvertising {
       return null;
     }
     let serviceData = ad.serviceData[0] || ad.serviceData;
+    let manufacturerData = ad.manufacturerData;
     let buf = serviceData.data;
-    if (!buf || !Buffer.isBuffer(buf) || buf.length < 3) {
+    
+    const bufIsInvalid = (!buf || !Buffer.isBuffer(buf) || buf.length < 3);
+    const manufacturerDataIsInvalid = (!manufacturerData 
+          || !Buffer.isBuffer(manufacturerData) 
+          || manufacturerData.length < 3);
+
+    if (bufIsInvalid && manufacturerDataIsInvalid) {
       return null;
     }
 
@@ -90,6 +97,8 @@ class SwitchbotAdvertising {
       sd = this._parseServiceDataForWoColorBulb(buf, onlog);
     } else if (model === 'g') { // WoPlugMini
       sd = this._parseServiceDataForWoPlugMini(buf, onlog);
+    } else if (model === 'j') { // WoPlugMini (JP) ?? 
+      sd = this._parseServiceDataForWoPlugMiniJ(manufacturerData, onlog);
     } else if (model === 'o') { // WoSmartLock
       sd = this._parseServiceDataForWoSmartLock(buf, onlog);
     } else if (model === 'i') { // WoMeterPlus
@@ -113,7 +122,7 @@ class SwitchbotAdvertising {
     if (address === '') {
       address = peripheral.advertisement.manufacturerData || '';
       if (address !== '') {
-        const str = peripheral.advertisement.manufacturerData.toString('hex').slice(4);
+        const str = peripheral.advertisement.manufacturerData.toString('hex')?.slice(4,16);
         address = str.substr(0, 2);
         for (var i = 2; i < str.length; i += 2) {
           address = address + ":" + str.substr(i, 2);
@@ -335,22 +344,37 @@ class SwitchbotAdvertising {
     return data;
   }
 
-  _parseServiceDataForWoPlugMini(buf, onlog) {
-    if (buf.length !== 6) {
+  _parseServiceDataForWoPlugMiniJ(buf, onlog) {
+    if (buf.length !== 14) {
       if (onlog && typeof onlog === 'function') {
-        onlog(`[_parseServiceDataForWoPlugMini] Buffer length ${buf.length} !== 6!`);
+        onlog(`[_parseServiceDataForWoPlugMiniJ] Buffer length ${buf.length} !== 6!`);
       }
       return null;
     }
-    let byte1 = buf.readUInt8(1);
-    let byte2 = buf.readUInt8(2);
-    // let byte3 = buf.readUInt8(3);
-    // let byte4 = buf.readUInt8(4);
-    let byte5 = buf.readUInt8(5);
+    const byte9 = buf.readUInt8(9);   // byte9:  plug mini state; 0x00=off, 0x80=on
+    const byte10 = buf.readUInt8(10); // byte10: bit0: 0=no delay,1=delay, bit1:0=no timer, 1=timer; bit2:0=no sync time, 1=sync'ed time
+    const byte11 = buf.readUInt8(11); // byte11: wifi rssi
+    const byte12 = buf.readUInt8(12); // byte12: bit7: overload?
+    const byte13 = buf.readUInt8(13); // byte12[bit0~6] + byte13: current power value
 
-    let data = {
-      model: 'g',
+    const state = byte9 === 0x00 ? 'off' : byte9 === 0x80 ? 'on' : null;
+    const delay = !! (byte10 & 0b00000001);
+    const timer = !! (byte10 & 0b00000010);
+    const syncUtcTime = !! (byte10 & 0b00000100);
+    const wifiRssi = byte11;
+    const overload = !! (byte12 & 0b10000000);
+    const currentPower = (((byte12 & 0b01111111) << 8) + byte13) / 10;
+
+    const data = {
+      model: 'j',
       modelName: 'WoPlugMini',
+      state: state,
+      delay: delay,
+      timer: timer,
+      syncUtcTime: syncUtcTime,
+      wifiRssi: wifiRssi,
+      overload: overload,
+      currentPower: currentPower
     };
 
     return data;

--- a/lib/switchbot-device-woplugmini.js
+++ b/lib/switchbot-device-woplugmini.js
@@ -1,0 +1,71 @@
+'use strict';
+const SwitchbotDevice = require('./switchbot-device.js');
+
+/**
+ * @see https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/latest/devicetypes/plugmini.md
+ */
+class SwitchbotDeviceWoPlugMini extends SwitchbotDevice {
+  /**
+   * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
+   */
+  readState() {
+    return this._operateBot([0x57, 0x0f, 0x51, 0x01]);
+  }
+
+  /**
+   * @private
+   */
+  _setState(reqByteArray) {
+    const base = [0x57, 0x0f, 0x50, 0x01];
+    return this._operateBot([].concat(base, reqByteArray));
+  }
+
+  /**
+   * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
+   */
+  turnOn() {
+    return this._setState([0x50, 0x01, 0x01, 0x80]);
+  }
+
+  /**
+   * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
+   */
+  turnOff() {
+    return this._setState([0x50, 0x01, 0x01, 0x00]);
+  }
+
+  /**
+   * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
+   */
+  toggle() {
+    return this._setState([0x50, 0x01, 0x02, 0x80]);
+  }
+
+  /**
+   * @private
+   */
+  _operateBot(bytes) {
+    return new Promise((resolve, reject) => {
+      let req_buf = Buffer.from([].concat([0x0f], bytes));
+      console.log("SEND COMMAND:", req_buf);
+      this._command(req_buf).then((res_buf) => {
+        if (res_buf.length === 2) {
+          let code = res_buf.readUInt8(1);
+          if (code === 0x00 || code === 0x80) {
+            const is_on = code === 0x80;
+            resolve(is_on);
+          } else {
+            reject(new Error('The device returned an error: 0x' + res_buf.toString('hex')));
+          }
+        } else {
+          reject(new Error('Expecting a 2-byte response, got instead: 0x' + res_buf.toString('hex')));
+        }
+      }).catch((error) => {
+        reject(error);
+      });
+    });
+  }
+
+}
+
+module.exports = SwitchbotDeviceWoPlugMini;

--- a/lib/switchbot-device-woplugmini.js
+++ b/lib/switchbot-device-woplugmini.js
@@ -46,9 +46,7 @@ class SwitchbotDeviceWoPlugMini extends SwitchbotDevice {
    */
   _operateBot(bytes) {
     return new Promise((resolve, reject) => {
-      let req_buf = Buffer.from([].concat([0x0f], bytes));
-      console.log("SEND COMMAND:", req_buf);
-      this._command(req_buf).then((res_buf) => {
+      this._command(req_buf).then(bytes => {
         if (res_buf.length === 2) {
           let code = res_buf.readUInt8(1);
           if (code === 0x00 || code === 0x80) {

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -9,6 +9,7 @@ const SwitchbotDeviceWoPresence = require('./switchbot-device-wopresence.js');
 const SwitchbotDeviceWoContact = require('./switchbot-device-wocontact.js');
 const SwitchbotDeviceWoSensorTH = require('./switchbot-device-wosensorth.js');
 const SwitchbotDeviceWoHumi = require('./switchbot-device-wohumi.js');
+const SwitchbotDeviceWoPlugMini = require('./switchbot-device-woplugmini.js');
 
 class Switchbot {
   /* ------------------------------------------------------------------
@@ -84,7 +85,7 @@ class Switchbot {
       // Check the parameters
       let valid = parameterChecker.check(params, {
         duration: { required: false, type: 'integer', min: 1, max: 60000 },
-        model: { required: false, type: 'string', enum: ['H', 'T', 'e', 's', 'd', 'c', 'u', 'g', 'o', 'i', 'r'] },
+        model: { required: false, type: 'string', enum: ['H', 'T', 'e', 's', 'd', 'c', 'u', 'g', 'j', 'o', 'i', 'r'] },
         id: { required: false, type: 'string', min: 12, max: 17 },
         quick: { required: false, type: 'boolean' }
       }, false);
@@ -210,6 +211,7 @@ class Switchbot {
           device = new SwitchbotDeviceWoColorBulb(peripheral, this.noble);
           break;
         case 'g':
+        case 'j':
           device = new SwitchbotDeviceWoPlugMini(peripheral, this.noble);
           break;
         case 'o':
@@ -305,7 +307,7 @@ class Switchbot {
     let promise = new Promise((resolve, reject) => {
       // Check the parameters
       let valid = parameterChecker.check(params, {
-        model: { required: false, type: 'string', enum: ['H', 'T', 'e', 's', 'd', 'c', 'u', 'g', 'o', 'i', 'r'] },
+        model: { required: false, type: 'string', enum: ['H', 'T', 'e', 's', 'd', 'c', 'u', 'g', 'j', 'o', 'i', 'r'] },
         id: { required: false, type: 'string', min: 12, max: 17 },
       }, false);
 


### PR DESCRIPTION
## :recycle: Current situation

Plug Mini JP (model `j`) advertisements are not parsed. There is no support to operate Plug Mini devices.

## :bulb: Proposed solution

Noble interprets Plug Mini JP differently. For some reason, advertisement payload is found in noble's `advertisement.manufacturerData`. An attempt is made to parse this data into meaningful information. The Plug Mini US (model `g` ?) may do so differently but I'm not sure.

## :gear: Release Notes

- support for model `j` PlugMini devices
- parses PlugMini advertisements into something like :
    ```
    {
      model: 'j',
      modelName: 'WoPlugMini',
      state: 'on',
      delay: false,
      timer: false,
      syncUtcTime: false,
      overload: true,
      currentPower: 33.5   // watt
    }
    ```
- the `SwitchbotDeviceWoPlugMini` class should function in theory, but doesn't work well with Raspberry Pi 3B+ (noble disconnects when `getService()` is called; this happens in python too, so I think this is a hardware issue. In fact the official app sometimes doesn't work (especially when signal is weak). 

## :heavy_plus_sign: Additional Information

Only tested on RasperryPi3B+

### Testing

(no tests were added)

### Reviewer Nudging

- the advertisement unit contains a new method to parse PlugMiniJ packets; coding style is a bit different, please advise if I should follow existing style
- the base switchbot-device unit contains changes to the parse method; please check if my changes are acceptable

Many thanks!