### PR TITLE
fix woplugmini _operateBot() method, mostly missing vars

### DIFF
--- a/lib/switchbot-device-woplugmini.js
+++ b/lib/switchbot-device-woplugmini.js
@@ -24,29 +24,31 @@ class SwitchbotDeviceWoPlugMini extends SwitchbotDevice {
    * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
    */
   turnOn() {
-    return this._setState([0x50, 0x01, 0x01, 0x80]);
+    return this._setState([0x01, 0x80]);
   }
 
   /**
    * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
    */
   turnOff() {
-    return this._setState([0x50, 0x01, 0x01, 0x00]);
+    return this._setState([0x01, 0x00]);
   }
 
   /**
    * @returns {Promise<boolean>} resolves with a boolean that tells whether the plug in ON(true) or OFF(false)
    */
   toggle() {
-    return this._setState([0x50, 0x01, 0x02, 0x80]);
+    return this._setState([0x02, 0x80]);
   }
 
   /**
    * @private
    */
   _operateBot(bytes) {
+    const req_buf = Buffer.from(bytes);
     return new Promise((resolve, reject) => {
-      this._command(req_buf).then(bytes => {
+      this._command(req_buf).then(res_bytes => {
+        const res_buf = Buffer.from(res_bytes);
         if (res_buf.length === 2) {
           let code = res_buf.readUInt8(1);
           if (code === 0x00 || code === 0x80) {


### PR DESCRIPTION
## :recycle: Current situation

I'm sorry, the previous commit contained faulty code. This PR fixes those.

## :bulb: Proposed solution

Fix to the followings
- incorrect buffer being sent on `turnOn` `turnOff` and `toggle` 
- confusing variable names  

## :gear: Release Notes

Bug fixes to the WoPlugMini class

## :heavy_plus_sign: Additional Information

I have been able to successfully operate a JP plug mini using a USB Bluetooth4 dongle (sold by [princeton](https://www.princeton.co.jp/product/accessory/ptmubt7.html)).

### Testing

```
const Switchbot = require('./node-switchbot');
const switchbot = new Switchbot();

function sleep(msec) {
    return new Promise(resolve => {
        setTimeout(()=>{ resolve(); }, msec);
    });
}

(async () => {
    console.log("discovering"); 
    const devices = await switchbot.discover({
        id: "6055f935f6a6",
        model: 'j',
    });

    console.log("turn off");
    const res1 = await devices[0].turnOff();
    console.log("==>", res1);

    await sleep(5000);

    console.log("turn on");
    const res2 = await devices[0].turnOn();
    console.log("==>", res2);
})();
```

output:

```
$ sudo node aa.js
discovering
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
processLeAdvertisingReport: Caught illegal packet (buffer overflow): TypeError: Cannot read property 'slice' of undefined
turn off
==> false
turn on
==> true
^C
```

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
