### PR TITLE
Improve error handling

### DIFF
--- a/lib/switchbot-device.js
+++ b/lib/switchbot-device.js
@@ -443,6 +443,9 @@ class SwitchbotDevice {
 
       this._connect()
         .then(() => {
+          if (!this._chars) {
+            return reject("No characteristics available.");
+          }
           return this._write(this._chars.write, req_buf);
         })
         .then(() => {

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -132,7 +132,9 @@ class Switchbot {
             for (let addr in peripherals) {
               device_list.push(peripherals[addr]);
             }
-            resolve(device_list);
+            if (device_list.length) {
+              resolve(device_list);
+            }
           };
 
           // Set a handler for the 'discover' event


### PR DESCRIPTION
## :recycle: Current situation

Some unhandled errors result in unreadable exceptions in Homebridge when using `homebridge-switchbot`.

## :bulb: Proposed solution

Handle errors more gracefully, it's likely that they could be prevented by changes in the async logic in this package.

3d4511a fixes the following error in Homebridge:
```
Bot: Light failed BLEpushChanges with BLE Connection & botMode: switch, Error Message: "Cannot read properties of undefined (reading 'turnOn')"
TypeError: Cannot read properties of undefined (reading 'turnOn')
    at fn (/usr/lib/node_modules/@switchbot/homebridge-switchbot/src/device/bot.ts:666:18)
    at Bot.retry (/usr/lib/node_modules/@switchbot/homebridge-switchbot/dist/device/bot.js:1115:16)
    at /usr/lib/node_modules/@switchbot/homebridge-switchbot/src/device/bot.ts:661:26
    at runNextTicks (node:internal/process/task_queues:60:5)
    at processTimers (node:internal/timers:504:9)
```

642e429 fixes the following error in Homebridge:
```
Curtain: Curtain failed BLEpushChanges with BLE Connection, Error Message: "Cannot read properties of null (reading 'write')"
TypeError: Cannot read properties of null (reading 'write')
TypeError: Cannot read properties of null (reading 'write')
    at /usr/lib/node_modules/@switchbot/homebridge-switchbot/node_modules/node-switchbot/lib/switchbot-device.js:449:42
    at runNextTicks (node:internal/process/task_queues:60:5)
    at listOnTimeout (node:internal/timers:533:9)
    at processTimers (node:internal/timers:507:7)
```

The latter error is easy to trigger from Homebridge by repeatedly switching a Bot off and on. This also causes all of Homebridge devices to become unresponsive for a short period of time. 
