### PR TITLE
Use Error object for promise rejection

### DIFF
--- a/lib/switchbot-device-wocurtain.js
+++ b/lib/switchbot-device-wocurtain.js
@@ -49,7 +49,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
 
   /* ------------------------------------------------------------------
    * runToPos()
-   * - run to the targe position
+   * - run to the target position
    *
    * [Arguments]
    * - percent | number | Required | the percentage of target position
@@ -63,7 +63,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
       return new Promise((resolve, reject) => {
         reject(
           new Error(
-            "The type of target position percentage is incorrent: " +
+            "The type of target position percentage is incorrect: " +
               typeof percent
           )
         );
@@ -75,7 +75,7 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
       if (typeof mode != "number") {
         return new Promise((resolve, reject) => {
           reject(
-            new Error("The type of running mode is incorrent: " + typeof mode)
+            new Error("The type of running mode is incorrect: " + typeof mode)
           );
         });
       }

--- a/lib/switchbot-device.js
+++ b/lib/switchbot-device.js
@@ -444,7 +444,7 @@ class SwitchbotDevice {
       this._connect()
         .then(() => {
           if (!this._chars) {
-            return reject("No characteristics available.");
+            return reject(new Error("No characteristics available."));
           }
           return this._write(this._chars.write, req_buf);
         })


### PR DESCRIPTION
## :recycle: Current situation

A string is used as a rejection.

## :bulb: Proposed solution

Use an Error object to be consistent.