### PR TITLE
Fixed 'TypeError: Assignment to constant variable'.

### DIFF
--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -595,8 +595,7 @@ class SwitchbotAdvertising {
 
     const temp_sign = byte4 & 0b10000000 ? 1 : -1;
     const temp_c = temp_sign * ((byte4 & 0b01111111) + (byte3 & 0b00001111) / 10);
-    const temp_f = (temp_c * 9 / 5) + 32;
-    temp_f = Math.round(temp_f * 10) / 10;
+    const temp_f = Math.round(((temp_c * 9 / 5) + 32) * 10) / 10;
 
     const data = {
       model: "i",

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -201,8 +201,7 @@ class SwitchbotAdvertising {
 
     const temp_sign = byte4 & 0b10000000 ? 1 : -1;
     const temp_c = temp_sign * ((byte4 & 0b01111111) + (byte3 & 0b00001111) / 10);
-    const temp_f = (temp_c * 9 / 5) + 32;
-    temp_f = Math.round(temp_f * 10) / 10;
+    const temp_f = Math.round(((temp_c * 9 / 5) + 32) * 10) / 10;
 
     const data = {
       model: "T",


### PR DESCRIPTION
Fixed run-time error 'TypeError: Assignment to constant variable' for meter devices. #184 introduced this bug.