### PR TITLE
add support for Curtain 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,7 +996,8 @@ Structure of the `serviceData`:
 
 | Property      | Type    | Description                                                                        |
 | :------------ | :------ | :--------------------------------------------------------------------------------- |
-| `model`       | String  | This value is always `"c"`, which means "Curtain (WoCurtain)".                     |
+| `model`       | String  | This value is `"c"`, which means "Curtain (WoCurtain)".                            |
+|               |         | or `"{"`, which means "Curtain 3 (WoCurtain)".                                     |
 | `modelName`   | String  | This value is always `"WoCurtain"`, which means "Curtain".                         |
 | `calibration` | Boolean | This value indicates the calibration status (`true` or `false`).                   |
 | `battery`     | Integer | This value indicates the battery level (`1-100`, `%`).                             |

--- a/README.md
+++ b/README.md
@@ -749,6 +749,14 @@ Actually, the `SwitchbotDeviceWoCurtain` is an object inherited from the [`Switc
 
 ### `open()` method
 
+The `open()` method sends a open command to the Curtain. This method returns a `Promise` object. Nothing will be passed to the `resove()`.
+
+If no connection is established with the device, this method automatically establishes a connection with the device, then finally closes the connection. You don't have to call the [`connect()`](#SwitchbotDevice-connect-method) method in advance.
+
+When the Curtain receives this command, the Curtain will open the curtain (0% position). If not calibrated, the Curtain does not move.
+
+The `open()` method receives an optional `mode` parameter. (See [`runToPos()`](#runtopos-method))
+
 ```javascript
 switchbot
   .discover({ model: "c", quick: true })
@@ -770,6 +778,8 @@ The `close()` method sends a close command to the Curtain. This method returns a
 If no connection is established with the device, this method automatically establishes a connection with the device, then finally closes the connection. You don't have to call the [`connect()`](#SwitchbotDevice-connect-method) method in advance.
 
 When the Curtain receives this command, the Curtain will close the curtain (100% position). If not calibrated, the Curtain does not move.
+
+The `close()` method receives an optional `mode` parameter. (See [`runToPos()`](#runtopos-method))
 
 ```javascript
 switchbot
@@ -1086,7 +1096,7 @@ Structure of the `serviceData`:
 | `delay`       | Boolean | Indicates whether a delay is present.                                               |
 | `timer`       | Boolean | Indicates whether a timer is present.                                               |
 | `syncUtcTime` | boolean | Indicates whether the UTC time has been synchronized.                               |
-| `overload`    | boolean | Indicates whether the Plug Mini is overloaded, more than 15A current overload.      |                            
+| `overload`    | boolean | Indicates whether the Plug Mini is overloaded, more than 15A current overload.      |
 | `currentPower`| Float   | Current power consumption in Watts.                                                 |
 
 ---

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -94,7 +94,7 @@ class SwitchbotAdvertising {
       sd = this._parseServiceDataForWoPresence(buf, onlog);//WoPresence
     } else if (model === "d") {
       sd = this._parseServiceDataForWoContact(buf, onlog);//WoContact
-    } else if (model === "c") {
+    } else if (model === "c" || model === "{") {
       sd = this._parseServiceDataForWoCurtain(buf, onlog);// WoCurtain
     } else if (model === "x") {
       sd = this._parseServiceDataForWoBlindTilt(buf, onlog);// WoBlindTilt
@@ -233,7 +233,7 @@ class SwitchbotAdvertising {
     }
     const byte1 = buf.readUInt8(1);
     const byte4 = buf.readUInt8(4);
-    
+
 
     const onState = byte1 & 0b10000000 ? true : false; // 1 - on
     const autoMode = byte4 & 0b10000000 ? true : false; // 1 - auto
@@ -545,7 +545,7 @@ class SwitchbotAdvertising {
     const byte7 = manufacturerData.readUInt8(7);
     const byte8 = manufacturerData.readUInt8(8);
 
-    
+
     const LockStatus = {
       LOCKED: 0b0000000,
       UNLOCKED: 0b0010000,

--- a/lib/switchbot-advertising.js
+++ b/lib/switchbot-advertising.js
@@ -355,9 +355,10 @@ class SwitchbotAdvertising {
     const currPosition = byte3 & 0b01111111; // current positon %
     const lightLevel = (byte4 >> 4) & 0b00001111; // light sensor level (1-10)
     const deviceChain = byte4 & 0b00000111;
+    const model = buf.slice(0, 1).toString("utf8");
 
     const data = {
-      model: "c",
+      model: model,
       modelName: "WoCurtain",
       calibration: calibration,
       battery: battery,

--- a/lib/switchbot-device-wocurtain.js
+++ b/lib/switchbot-device-wocurtain.js
@@ -10,14 +10,14 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
    * - Open the curtain
    *
    * [Arguments]
-   * - none
+   * - mode | number | Opetional | runing mode (0x01 = QuietDrift, 0xff = Default)
    *
    * [Return value]
    * - Promise object
    *   Nothing will be passed to the `resolve()`.
    * ---------------------------------------------------------------- */
-  open() {
-    return this._operateCurtain([0x57, 0x0f, 0x45, 0x01, 0x05, 0xff, 0x00]);
+  open(mode) {
+    return this.runToPos(0, mode);
   }
 
   /* ------------------------------------------------------------------
@@ -25,14 +25,14 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
    * - close the curtain
    *
    * [Arguments]
-   * - none
+   * - mode | number | Opetional | runing mode (0x01 = QuietDrift, 0xff = Default)
    *
    * [Return value]
    * - Promise object
    *   Nothing will be passed to the `resolve()`.
    * ---------------------------------------------------------------- */
-  close() {
-    return this._operateCurtain([0x57, 0x0f, 0x45, 0x01, 0x05, 0xff, 0x64]);
+  close(mode) {
+    return this.runToPos(100, mode);
   }
 
   /* ------------------------------------------------------------------
@@ -55,13 +55,14 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
    * - run to the target position
    *
    * [Arguments]
-   * - percent | number | Required | the percentage of target position
+   * - percent | number | Required  | the percentage of target position
+   * - mode    | number | Opetional | runing mode (0x01 = QuietDrift, 0xff = Default)
    *
    * [Return value]
    * - Promise object
    *   Nothing will be passed to the `resolve()`.
    * ---------------------------------------------------------------- */
-  runToPos(percent, mode) {
+  runToPos(percent, mode = 0xff) {
     if (typeof percent != "number") {
       return new Promise((resolve, reject) => {
         reject(
@@ -72,19 +73,15 @@ class SwitchbotDeviceWoCurtain extends SwitchbotDevice {
         );
       });
     }
-    if (mode == null) {
+    if (typeof mode != "number") {
+      return new Promise((resolve, reject) => {
+        reject(
+          new Error("The type of running mode is incorrect: " + typeof mode)
+        );
+      });
+    }
+    if (mode > 1) {
       mode = 0xff;
-    } else {
-      if (typeof mode != "number") {
-        return new Promise((resolve, reject) => {
-          reject(
-            new Error("The type of running mode is incorrect: " + typeof mode)
-          );
-        });
-      }
-      if (mode > 1) {
-        mode = 0xff;
-      }
     }
     if (percent > 100) {
       percent = 100;

--- a/lib/switchbot.js
+++ b/lib/switchbot.js
@@ -56,13 +56,14 @@ class Switchbot {
    *   - duration | Integer | Optional | Duration for discovery process (msec).
    *              |         |          | The value must be in the range of 1 to 60000.
    *              |         |          | The default value is 5000 (msec).
-   *   - model    | String  | Optional | "H", "T", "e", "s", "d", "c", "u", "g", "o", "i", or "r".
+   *   - model    | String  | Optional | "H", "T", "e", "s", "d", "c", "{", "u", "g", "o", "i", or "r".
    *              |         |          | If "H" is specified, this method will discover only Bots.
    *              |         |          | If "T" is specified, this method will discover only Meters.
    *              |         |          | If "e" is specified, this method will discover only Humidifiers.
    *              |         |          | If "s" is specified, this method will discover only Motion Sensors.
    *              |         |          | If "d" is specified, this method will discover only Contact Sensors.
    *              |         |          | If "c" is specified, this method will discover only Curtains.
+   *              |         |          | If "{" is specified, this method will discover only Curtain 3.
    *              |         |          | If "u" is specified, this method will discover only Color Bulbs.
    *              |         |          | If "g" is specified, this method will discover only Plugs.
    *              |         |          | If "o" is specified, this method will discover only Locks.
@@ -101,6 +102,7 @@ class Switchbot {
               "s",
               "d",
               "c",
+              "{",
               "u",
               "g",
               "j",
@@ -252,6 +254,7 @@ class Switchbot {
           device = new SwitchbotDeviceWoContact(peripheral, this.noble);
           break;
         case "c":
+        case "{":
           device = new SwitchbotDeviceWoCurtain(peripheral, this.noble);
           break;
         case "x":
@@ -310,7 +313,7 @@ class Switchbot {
    *
    * [Arguments]
    *   - params   | Object  | Optional |
-   *   - model    | String  | Optional | "H", "T", "e", "s", "d", "c", "u", "g", "o", "i", "x", or "r".
+   *   - model    | String  | Optional | "H", "T", "e", "s", "d", "c", "{", "u", "g", "o", "i", "x", or "r".
    *              |         |          | If "H" is specified, the `onadvertisement`
    *              |         |          | event handler will be called only when advertising
    *              |         |          | packets comes from Bots.
@@ -329,6 +332,9 @@ class Switchbot {
    *              |         |          | If "c" is specified, the `onadvertisement`
    *              |         |          | event handler will be called only when advertising
    *              |         |          | packets comes from Curtains.
+   *              |         |          | If "{" is specified, the `onadvertisement`
+   *              |         |          | event handler will be called only when advertising
+   *              |         |          | packets comes from Curtain 3.
    *              |         |          | If "x" is specified, the `onadvertisement`
    *              |         |          | event handler will be called only when advertising
    *              |         |          | packets comes from BlindTilt.
@@ -375,6 +381,7 @@ class Switchbot {
               "s",
               "d",
               "c",
+              "{",
               "u",
               "g",
               "j",


### PR DESCRIPTION
## :recycle: Current situation

Switchbot Curtain 3 is not supported.

## :bulb: Proposed solution

Add optional Parameter to `open()` and `close()` methods to be passed through to `runToPos()` for QuietDrift support
Add model identifier for Curtain 3

## :gear: Release Notes

Curtain 3 devices are now supported

## :heavy_plus_sign: Additional Information

### Testing

### Reviewer Nudging
