### PR TITLE
Fix warnings

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -426,7 +426,7 @@ export class SwitchbotDevice {
       );
 
       if (!valid) {
-        reject(new Error(parameterChecker?.error?.message));
+        reject(new Error(parameterChecker.error!.message));
         return;
       }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -4,7 +4,7 @@
  */
 import Noble from '@abandonware/noble';
 import { parameterChecker } from './parameter-checker.js';
-import { Advertising, Ad } from './advertising.js';
+import { Advertising } from './advertising.js';
 
 type Chars = {
   write: Noble.Characteristic | null,
@@ -47,7 +47,7 @@ export class SwitchbotDevice {
     this._chars = null;
 
     // Save the device information
-    const ad: Ad = Advertising.parse(peripheral);
+    const ad = Advertising.parse(peripheral);
     this._id = ad ? ad.id : null;
     this._address = ad ? ad.address : null;
     this._model = ad ? ad.serviceData.model : null;

--- a/src/parameter-checker.ts
+++ b/src/parameter-checker.ts
@@ -61,7 +61,7 @@ class ParameterChecker {
    *   }
    * });
    * if(!valid) {
-   *   const e = parameterChecker.error.message;
+   *   const message = parameterChecker.error.message;
    *   throw new Error(message);
    * }
    * ---------------------------------------------------------------- */

--- a/src/switchbot.ts
+++ b/src/switchbot.ts
@@ -158,7 +158,7 @@ export class SwitchBot {
       // Initialize the noble object
       this._init()
         .then(() => {
-          if (this.noble == null) {
+          if (this.noble === null) {
             return reject(new Error('noble failed to initialize'));
           }
           const peripherals: Record<string, SwitchbotDevice> = {};
@@ -167,10 +167,10 @@ export class SwitchBot {
             if (timer) {
               clearTimeout(timer);
             }
-            
+
             this.noble.removeAllListeners('discover');
             this.noble.stopScanning();
-            
+
             const device_list: SwitchbotDevice[] = [];
             for (const addr in peripherals) {
               device_list.push(peripherals[addr]);
@@ -432,7 +432,7 @@ export class SwitchBot {
       // Initialize the noble object
       this._init()
         .then(() => {
-          if (this.noble == null) {
+          if (this.noble === null) {
             return reject(new Error('noble object failed to initialize'));
           }
           // Determine the values of the parameters
@@ -485,7 +485,9 @@ export class SwitchBot {
      * - none
      * ---------------------------------------------------------------- */
   stopScan() {
-    if (this.noble == null) return;
+    if (this.noble === null) {
+      return;
+    }
 
     this.noble.removeAllListeners('discover');
     this.noble.stopScanning();

--- a/src/switchbot.ts
+++ b/src/switchbot.ts
@@ -139,7 +139,7 @@ export class SwitchBot {
       );
 
       if (!valid) {
-        reject(new Error(parameterChecker?.error?.message));
+        reject(new Error(parameterChecker.error!.message));
         return;
       }
 
@@ -425,7 +425,7 @@ export class SwitchBot {
         false,
       );
       if (!valid) {
-        reject(new Error(parameterChecker?.error?.message));
+        reject(new Error(parameterChecker.error!.message));
         return;
       }
 
@@ -516,7 +516,7 @@ export class SwitchBot {
       );
 
       if (!valid) {
-        reject(new Error(parameterChecker?.error?.message));
+        reject(new Error(parameterChecker.error!.message));
         return;
       }
       // Set a timer

--- a/src/switchbot.ts
+++ b/src/switchbot.ts
@@ -223,7 +223,7 @@ export class SwitchBot {
     await this.ready;
     const promise = new Promise<void>((resolve, reject) => {
       let err;
-      if (this.noble?._state === 'poweredOn') {
+      if (this.noble._state === 'poweredOn') {
         resolve();
         return;
       }
@@ -233,14 +233,14 @@ export class SwitchBot {
           case 'unauthorized':
           case 'poweredOff':
             err = new Error(
-              'Failed to initialize the Noble object: ' + this.noble?._state,
+              'Failed to initialize the Noble object: ' + this.noble._state,
             );
             reject(err);
             return;
           case 'resetting':
           case 'unknown':
             err = new Error(
-              'Adapter is not ready: ' + this.noble?._state,
+              'Adapter is not ready: ' + this.noble._state,
             );
             reject(err);
             return;
@@ -249,7 +249,7 @@ export class SwitchBot {
             return;
           default:
             err = new Error(
-              'Unknown state: ' + this.noble?._state,
+              'Unknown state: ' + this.noble._state,
             );
             reject(err);
             return;


### PR DESCRIPTION
## :recycle: Current situation

Some optional chaining operators were introduced after others being removed in https://github.com/OpenWonderLabs/node-switchbot/pull/232.

## :bulb: Proposed solution

Remove them and fix new warnings.

@brozef I assume you removed the optional chaining operators for Node.js 12 compatibility but are passing the `noble` instance, as the [dynamic import](https://github.com/OpenWonderLabs/node-switchbot/blob/c0a3668/src/switchbot.ts#L65) is only supported in Node.js 14.