### PR TITLE
add link to my script 'get-encryption-key' npm script in BLE.md

### DIFF
--- a/BLE.md
+++ b/BLE.md
@@ -731,6 +731,7 @@ Actually, the `WoSmartLock ` is an object inherited from the [`SwitchbotDevice`]
 The `setKey()` method initialises the key information required for encrypted communication with the SmartLock
 
 This must be set before any control commands are sent to the device. To obtain the key information you will need to use an external tool - see [`pySwitchbot`](https://github.com/Danielhiversen/pySwitchbot/tree/master?tab=readme-ov-file#obtaining-locks-encryption-key) project for an example script.
+Or, use [`switchbot-get-encryption-key`](https://www.npmjs.com/package/switchbot-get-encryption-key) npm script.
 
 | Property        | Type   | Description                                                                                      |
 | :-------------- | :----- | :----------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## :recycle: Current situation

When using `WoSmartLock` object, `setKey()`, user need to obtain encryption key by `pySwitchBot` script which is written in `Python`.
Developers who use `node-switchbot` are familiar with npm/NodeJS, but may have troublesome for using python script.

I just developed **NodeJS based** script, switchbot-get-encryption-key which is just download by `npm`.
This script may be more useful for `node-switchbot` users who want to obtain key ID and encryption key.

## :bulb: Proposed solution

Just adding link to npm page for my script in `BLE.md` document for developer convenience.

### Testing

Click the link in BLE.md file so that there is any link error.

