### PR TITLE
Change scanning log level

### DIFF
--- a/BLE.md
+++ b/BLE.md
@@ -1089,7 +1089,7 @@ In this code, you can get a [`WoHand`](#SwitchbotDeviceWoHand-object) object rep
 
 ### Logging
 
-To be able to receive logging that this module is pushing out you will need to subscribt to the events.
+To be able to receive logging that this module is pushing out you will need to subscribe to the events.
 
 ```typescript
 this.switchBotBLE.on('log', (log) => {

--- a/src/switchbot-ble.ts
+++ b/src/switchbot-ble.ts
@@ -160,7 +160,7 @@ export class SwitchBotBLE extends EventEmitter {
         this.noble.removeAllListeners('discover')
         try {
           await this.noble.stopScanningAsync()
-          this.log('info', 'Stopped Scanning for SwitchBot BLE devices.')
+          this.log('debug', 'Stopped Scanning for SwitchBot BLE devices.')
         } catch (e: any) {
           this.log('error', `discover stopScanningAsync error: ${JSON.stringify(e.message ?? e)}`)
         }
@@ -282,7 +282,7 @@ export class SwitchBotBLE extends EventEmitter {
 
     try {
       await this.noble.startScanningAsync(PRIMARY_SERVICE_UUID_LIST, true)
-      this.log('info', 'Started Scanning for SwitchBot BLE devices.')
+      this.log('debug', 'Started Scanning for SwitchBot BLE devices.')
     } catch (e: any) {
       this.log('error', `startScanningAsync error: ${JSON.stringify(e.message ?? e)}`)
     }
@@ -301,7 +301,7 @@ export class SwitchBotBLE extends EventEmitter {
     this.noble.removeAllListeners('discover')
     try {
       await this.noble.stopScanningAsync()
-      this.log('info', 'Stopped Scanning for SwitchBot BLE devices.')
+      this.log('debug', 'Stopped Scanning for SwitchBot BLE devices.')
     } catch (e: any) {
       this.log('error', `stopScanningAsync error: ${JSON.stringify(e.message ?? e)}`)
     }


### PR DESCRIPTION
## :recycle: Current situation

Scanning logging now occurs every few minutes, which seems excessive.

## :bulb: Proposed solution

Change the logging level so important logging messages are visible.

One could argue this could also be handled in the https://github.com/OpenWonderLabs/homebridge-switchbot/ project.