### PR TITLE
Fix the return value of `SwitchBotOpenAPI.getDeviceStatus()` method

### DIFF
--- a/src/switchbot-openapi.ts
+++ b/src/switchbot-openapi.ts
@@ -198,7 +198,7 @@ export class SwitchBotOpenAPI extends EventEmitter {
       const configToken = token || this.token
       const configSecret = secret || this.secret
       const { body, statusCode } = await request(`${urls.devicesURL}/${deviceId}/status`, { headers: this.generateHeaders(configToken, configSecret) })
-      const response = await body.json() as deviceStatus
+      const { body: response } = await body.json() as deviceStatusRequest
       this.emitLog('debug', `Got device status: ${deviceId}`)
       this.emitLog('debug', `statusCode: ${statusCode}`)
       return { response, statusCode }


### PR DESCRIPTION
## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

`SwitchBotOpenAPI.getDeviceStatus()` method returns an object like below:

```
{
  response: {
    statusCode: 100,
    body: {
      version: 'V2.9',
      battery: 41,
      lockState: 'locked',
      doorState: 'closed',
      calibrate: true,
      deviceId: 'XXXXXXXX',
      deviceType: 'XXXXXXXX',
      hubDeviceId: 'XXXXXXXX'
    },
    message: 'success'
  },
  statusCode: 200
}
```

But `SwitchBotOpenAPI.getDeviceStatus()` expects to return `{ response: deviceStatus, statusCode: deviceStatusRequest['statusCode'] }` type.

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

[This line](https://github.com/OpenWonderLabs/node-switchbot/blob/ca9e2255e7a50bdb709058c259f2581dc3ee7467/src/switchbot-openapi.ts#L201) does not return `deviceStatus` type but `deviceStatusRequest` type. So this PR fix the internal type in the `getDeviceStatus()` method so that it returns an expected object.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
