### PR TITLE
Fix WoPlugMiniUS TypeError

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -2537,11 +2537,11 @@ export class WoPlugMiniJP extends SwitchbotDevice {
    * @returns {Promise<plugMiniJPServiceData | null>} - Parsed service data or null if invalid.
    */
   static async parseServiceData(
-    manufacturerData: Buffer,
+    manufacturerData: Buffer | undefined,
     emitLog: (level: string, message: string) => void,
   ): Promise<plugMiniJPServiceData | null> {
-    if (manufacturerData.length !== 14) {
-      emitLog('debugerror', `[parseServiceDataForWoPlugMiniJP] Buffer length ${manufacturerData.length} should be 14`)
+    if (!manufacturerData || manufacturerData.length !== 14) {
+      emitLog('debugerror', `[parseServiceDataForWoPlugMiniJP] Buffer length ${manufacturerData?.length ?? 0} should be 14`)
       return null
     }
 
@@ -2659,11 +2659,11 @@ export class WoPlugMiniEU extends SwitchbotDevice {
    * @returns {Promise<plugMiniEUServiceData | null>} - Parsed service data or null if invalid.
    */
   static async parseServiceData(
-    manufacturerData: Buffer,
+    manufacturerData: Buffer | undefined,
     emitLog: (level: string, message: string) => void,
   ): Promise<plugMiniEUServiceData | null> {
-    if (manufacturerData.length !== 14) {
-      emitLog('debugerror', `[parseServiceDataForWoPlugMiniEU] Buffer length ${manufacturerData.length} should be 14`)
+    if (!manufacturerData || manufacturerData.length !== 14) {
+      emitLog('debugerror', `[parseServiceDataForWoPlugMiniEU] Buffer length ${manufacturerData?.length ?? 0} should be 14`)
       return null
     }
 
@@ -2780,11 +2780,11 @@ export class WoPlugMiniUS extends SwitchbotDevice {
    * @returns {Promise<plugMiniUSServiceData | null>} - Parsed service data or null if invalid.
    */
   static async parseServiceData(
-    manufacturerData: Buffer,
+    manufacturerData: Buffer | undefined,
     emitLog: (level: string, message: string) => void,
   ): Promise<plugMiniUSServiceData | null> {
-    if (manufacturerData.length !== 14) {
-      emitLog('debugerror', `[parseServiceDataForWoPlugMini] Buffer length ${manufacturerData.length} should be 14`)
+    if (!manufacturerData || manufacturerData.length !== 14) {
+      emitLog('debugerror', `[parseServiceDataForWoPlugMini] Buffer length ${manufacturerData?.length ?? 0} should be 14`)
       return null
     }
 


### PR DESCRIPTION
## :recycle: Current situation

The following exception can occur when 'g' BLE devices are within range:

```
TypeError: Cannot read properties of undefined (reading 'length')
at WoPlugMiniUS.parseServiceData (file:///var/lib/homebridge/node_modules/device.ts:2786:26)
at Advertising.parseServiceData (file:///var/lib/homebridge/node_modules/device.ts:1102:29)
at Advertising.parse (file:///var/lib/homebridge/node_modules/device.ts:1008:34)
at Noble.<anonymous> (file:///var/lib/homebridge/node_modules/switchbot-ble.ts:292:32)
at Noble.emit (node:events:508:28)
at Noble._onDiscover (/var/lib/homebridge/node_modules/@switchbot/homebridge-switchbot/node_modules/noble.js:357:12)
at NobleBindings.emit (node:events:508:28)
at NobleBindings.onDiscover (/var/lib/homebridge/node_modules/@switchbot/homebridge-switchbot/node_modules/bindings.js:271:10)
at Gap.emit (node:events:508:28)
at Gap.onHciLeAdvertisingReport (/var/lib/homebridge/node_modules/@switchbot/homebridge-switchbot/node_modules/gap.js:174:10)
```

The ad data:
```
{
  localName: undefined,
  txPowerLevel: undefined,
  manufacturerData: undefined,
  serviceData: [ { uuid: 'fe0f', data: <Buffer 67 10 ff ff 02> } ],
  serviceUuids: [ 'fe0f' ],
  serviceSolicitationUuids: []
}
```

## :bulb: Proposed solution

Improve `manufacturerData` handling.